### PR TITLE
Feat/lazy parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,26 @@ homepage = "https://ironfish.network/"
 repository = "https://github.com/iron-fish/ironfish-frost"
 
 [dependencies]
+
+ed25519-dalek = { version = "2.1.0", default-features = false, features = [
+    "rand_core",
+    "alloc",
+] }
 blake3 = { version = "1.5.0", optional = true, default-features = false }
 chacha20 = "0.9.1"
 chacha20poly1305 = "0.10.1"
-ed25519-dalek = { version = "2.1.0", default-features = false, features = ["rand_core", "alloc"] }
 rand_chacha = { version = "0.3.1", optional = true, default-features = false }
-rand_core = { version = "0.6.4", default-features = false, features = ["alloc"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev="9ac52c5c60e454b0032d78a22c05fb79aae1d51e", features = ["frost"], default-features = false }
+rand_core = { version = "0.6.4", default-features = false, features = [
+    "alloc",
+] }
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "9ac52c5c60e454b0032d78a22c05fb79aae1d51e", features = [
+    "frost",
+], default-features = false }
 siphasher = { version = "1.0.0", default-features = false }
-x25519-dalek = { version = "2.0.0", default-features = false, features = ["reusable_secrets", "static_secrets"] }
+x25519-dalek = { version = "2.0.0", default-features = false, features = [
+    "reusable_secrets",
+    "static_secrets",
+] }
 
 [dev-dependencies]
 hex-literal = "0.4.1"
@@ -29,3 +40,4 @@ default = ["signing"]
 std = []
 signing = ["dep:blake3", "dep:rand_chacha"]
 dkg = []
+ledger = []

--- a/src/dkg/group_key.rs
+++ b/src/dkg/group_key.rs
@@ -34,6 +34,7 @@ impl GroupSecretKeyShard {
     }
 
     #[must_use]
+    #[inline(never)]
     pub fn combine<'a, I: IntoIterator<Item = &'a Self>>(shards: I) -> GroupSecretKey {
         let mut shards = shards.into_iter();
         let mut key = shards

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -201,7 +201,6 @@ where
     zlog_stack("round1::input_checksum\0");
 
     let participants = sort_participants(participants);
-    // let mut participants = participants.into_iter().cloned().sorted().dedup();
 
     let mut hasher = ChecksumHasher::new();
 
@@ -219,7 +218,7 @@ pub(super) fn sort_participants<'a, I>(participants: I) -> impl Iterator<Item = 
 where
     I: IntoIterator<Item = &'a Identity>,
 {
-    // let mut sorted_set = alloc::collections::BTreeSet::new();
+    // use a BTreeSet to reduce stack usage
     let sorted = participants
         .into_iter()
         .map(|id| id.clone())

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -340,6 +340,7 @@ impl CombinedPublicPackage {
         )?)
     }
 
+    #[inline(never)]
     pub fn deserialize_from<R: io::Read>(mut reader: R) -> Result<Self, IronfishFrostError> {
         let sender_identity = Identity::deserialize_from(&mut reader)?;
 

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -203,33 +203,6 @@ where
 #[cfg(feature = "ledger")]
 #[must_use]
 #[inline(never)]
-pub(super) fn input_checksum<'a, P>(round1_packages: P) -> Checksum
-where
-    P: IntoIterator<Item = &'a round1::PublicPackage>,
-{
-    zlog_stack("round2::input_checksum\0");
-    let mut hasher = ChecksumHasher::new();
-
-    // TODO: This wont work with lazy parsing because each P in list is replaced with
-    // the following one
-    let mut round1_packages = round1_packages.into_iter().collect::<Vec<_>>();
-    zlog_stack("collected**\0");
-
-    // unfortunate we need to clone identities
-    round1_packages.sort_unstable_by_key(|p| p.identity());
-    round1_packages.dedup();
-    let round1_packages = round1_packages;
-
-    for package in round1_packages {
-        hasher.write(&package.serialize());
-    }
-
-    hasher.finish()
-}
-
-#[cfg(feature = "ledger")]
-#[must_use]
-#[inline(never)]
 pub(super) fn input_checksum_lazy<'a, P>(round1_packages: P) -> Checksum
 where
     P: IntoIterator<Item = &'a round1::PublicPackage> + Clone,

--- a/src/dkg/round3.rs
+++ b/src/dkg/round3.rs
@@ -358,6 +358,7 @@ fn compute_round1_checksum<'a, P>(
 where
     P: IntoIterator<Item = &'a round1::PublicPackage> + Clone,
 {
+    zlog_stack("compute_round1_checksum\0");
     let iter = round1_public_packages
         .clone()
         .into_iter()
@@ -373,6 +374,7 @@ fn compute_round2_checksum<'a, P>(round1_public_packages: &P) -> Result<u64, Iro
 where
     P: IntoIterator<Item = &'a round1::PublicPackage> + Clone,
 {
+    zlog_stack("compute_round1_checksum\0");
     let iter = round1_public_packages.clone();
 
     let checksum = round2::input_checksum_lazy(iter);
@@ -389,12 +391,19 @@ where
     P: IntoIterator<Item = &'a round1::PublicPackage> + Clone,
     Q: IntoIterator<Item = &'a round2::CombinedPublicPackage> + Clone,
 {
+    zlog_stack("package_sizes\0");
     let (size_round1, _) = round1_public_packages.clone().into_iter().size_hint();
     let (size_round2, _) = round2_public_packages.clone().into_iter().size_hint();
+    zlog_stack("package_sizes_done!\0");
 
     (size_round1, size_round2)
 }
 
+// Ideally we should rename this function
+// to make it clear that it is use for lazy parsing
+// of input data, however this would require renaming
+// the tests bellow, so for now we run those tests by enabling
+// the ledger feature an ensure every change we did works fine
 #[cfg(feature = "ledger")]
 #[inline(never)]
 pub fn round3<'a, P, Q>(
@@ -470,6 +479,7 @@ where
 
     assert_eq!(round2_public_packages_len, round2_frost_packages.len());
 
+    // zlog_stack("calling part3***\0");
     let (key_package, public_key_package) = part3(
         &round2_secret_package,
         &round1_frost_packages,

--- a/src/dkg/utils.rs
+++ b/src/dkg/utils.rs
@@ -17,14 +17,10 @@ pub fn zlog(buf: &str) {
     unsafe {
         zemu_log(buf.as_bytes().as_ptr())
     }
-    // #[cfg(test)]
-    // std::println!("{}", buf);
 }
 pub fn zlog_stack(buf: &str) {
     #[cfg(not(test))]
     unsafe {
         zemu_log_stack(buf.as_bytes().as_ptr())
     }
-    // #[cfg(test)]
-    // std::println!("{}", buf);
 }

--- a/src/dkg/utils.rs
+++ b/src/dkg/utils.rs
@@ -17,14 +17,14 @@ pub fn zlog(buf: &str) {
     unsafe {
         zemu_log(buf.as_bytes().as_ptr())
     }
-    #[cfg(test)]
-    std::println!("{}", buf);
+    // #[cfg(test)]
+    // std::println!("{}", buf);
 }
 pub fn zlog_stack(buf: &str) {
     #[cfg(not(test))]
     unsafe {
         zemu_log_stack(buf.as_bytes().as_ptr())
     }
-    #[cfg(test)]
-    std::println!("{}", buf);
+    // #[cfg(test)]
+    // std::println!("{}", buf);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod io {
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]
-mod io {
+pub mod io {
     use core::cmp;
     use core::mem;
 


### PR DESCRIPTION
changes that aim to be compatible with lazy parsing plus some parsing strategies to improve memory usage:

- Add a deserialize_from_into to different types involved in the deserialization of round1::PublicPackage
- Add lazy computation of checksums, because the current implementation assumes that the iterator points to a full vector/list of parsed values, however our iterator yields a fully parsed value at any time, this hits performance because sometimes we need to iterate twice(round2::input_checksum()) but this is also a strategy to reduce heap allocations.
- Add "ledger" feature flag, so users does not get affected by this change unless they opt-in by enabling this flag. 